### PR TITLE
Fix: python=3.10 should not be included when only --keep-tree=python=3.9 was requested

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,6 @@ jobs:
           pixi run --environment ${{ env.PIXI_ENV_NAME }} dev
       - name: Run tests
         run: pixi run --environment ${{ env.PIXI_ENV_NAME }} test --basetemp=${{ runner.os == 'Windows' && 'D:\\temp' || runner.temp }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: matrix.python-version == '310'
-        timeout-minutes: 45
       - name: Build recipe (${{ env.PIXI_ENV_NAME }})
         if: matrix.python-version == '310'
         run: pixi run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,10 @@ jobs:
           pixi run --environment ${{ env.PIXI_ENV_NAME }} dev
       - name: Run tests
         run: pixi run --environment ${{ env.PIXI_ENV_NAME }} test --basetemp=${{ runner.os == 'Windows' && 'D:\\temp' || runner.temp }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: matrix.python-version == '310'
+        timeout-minutes: 45
       - name: Build recipe (${{ env.PIXI_ENV_NAME }})
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '310'
         run: pixi run build

--- a/conda_subchannel/cli.py
+++ b/conda_subchannel/cli.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import argparse
 from logging import getLogger
 from datetime import datetime, timezone
-from unittest import mock
 
 from conda.exceptions import ArgumentError
 from conda.base.constants import REPODATA_FN
@@ -16,7 +15,7 @@ from conda.common.io import Spinner
 
 from .core import _fetch_channel, _reduce_index, _dump_records, _write_to_disk
 
-logger = getLogger(f"conda.{__name__}")
+log = getLogger(f"conda.{__name__}")
 
 
 def date_argument(date: str) -> float:
@@ -93,9 +92,7 @@ def execute(args: argparse.Namespace) -> int:
     if not any([args.after, args.before, args.keep, args.remove, args.keep_tree]):
         raise ArgumentError("Please provide at least one filter.")
 
-    with Spinner("Syncing source channel"), mock.patch.object(
-        context, "add_pip_as_python_dependency", False
-    ):
+    with Spinner("Syncing source channel"):
         subdir_datas = _fetch_channel(
             args.channel, args.subdirs or context.subdirs, args.repodata_fn
         )

--- a/conda_subchannel/cli.py
+++ b/conda_subchannel/cli.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 import argparse
 from logging import getLogger
 from datetime import datetime, timezone
+from unittest import mock
 
 from conda.exceptions import ArgumentError
+from conda.base.constants import REPODATA_FN
 from conda.base.context import context
 from conda.common.io import Spinner
-from conda.base.constants import REPODATA_FN
 
 from .core import _fetch_channel, _reduce_index, _dump_records, _write_to_disk
 
@@ -92,7 +93,9 @@ def execute(args: argparse.Namespace) -> int:
     if not any([args.after, args.before, args.keep, args.remove, args.keep_tree]):
         raise ArgumentError("Please provide at least one filter.")
 
-    with Spinner("Syncing source channel"):
+    with Spinner("Syncing source channel"), mock.patch.object(
+        context, "add_pip_as_python_dependency", False
+    ):
         subdir_datas = _fetch_channel(
             args.channel, args.subdirs or context.subdirs, args.repodata_fn
         )

--- a/tests/test_subchannel.py
+++ b/tests/test_subchannel.py
@@ -77,7 +77,6 @@ def test_python_tree(conda_cli, tmp_path, monkeypatch):
     assert python_count
     assert other_count
 
-    monkeypatch.setenv("CONDA_PKGS_DIRS", str(tmp_path / "pkgs"))
     # This should be solvable
     with pytest.raises(DryRunExit):
         conda_cli(

--- a/tests/test_subchannel.py
+++ b/tests/test_subchannel.py
@@ -5,6 +5,7 @@ import pytest
 from conda.base.context import context
 from conda.core.subdir_data import SubdirData
 from conda.models.channel import Channel
+from conda.models.match_spec import MatchSpec
 from conda.exceptions import ArgumentError, DryRunExit, PackagesNotFoundError
 from conda.testing import conda_cli  # noqa
 
@@ -45,13 +46,14 @@ def test_only_python(conda_cli, tmp_path):
 
 
 def test_python_tree(conda_cli, tmp_path, monkeypatch):
+    spec = "python=3.9"
     channel_path = tmp_path / "channel"
     out, err, rc = conda_cli(
         "subchannel",
         "-c",
         "conda-forge",
         "--keep-tree",
-        "python=3.9",
+        spec,
         "--output",
         channel_path,
     )
@@ -65,8 +67,10 @@ def test_python_tree(conda_cli, tmp_path, monkeypatch):
     sd.load()
     python_count = 0
     other_count = 0
+    py39 = MatchSpec(spec)
     for record in sd.iter_records():  # we should see Python and their dependencies
         if record.name == "python":
+            assert py39.match(record)
             python_count += 1
         else:
             other_count += 1


### PR DESCRIPTION
This has to do with dependency cycles like `python -> pip -> python` caused by `context.add_pip_as_python_dependency`. 

The solution so far seems to be filter the recursively added tree to remove any (in this case) Python version other than 3.9. We match per name and filter out if the full spec doesn't match the record.